### PR TITLE
Link para horario curso en otros timezones y corrección de pruebas cucumber

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-rvm: 2.6.4
+rvm: 2.6.7
 sudo: false
 services:
 - xvfb

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ end
 group :development, :test do
   gem 'rspec'
   gem 'cucumber'
-  gem 'webrat'
+  gem 'capybara'
   gem 'simplecov'
   gem 'coveralls', "~> 0.8", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "2.6.4"
+ruby "2.6.7"
 
 gem 'sinatra'
 gem 'thin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ DEPENDENCIES
   webrat
 
 RUBY VERSION
-   ruby 2.6.4p104
+   ruby 2.6.7p197
 
 BUNDLED WITH
    2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,17 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
+    capybara (3.35.3)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.1.7)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
@@ -66,6 +76,7 @@ GEM
     json (2.3.1)
     libxml-ruby (3.2.0)
     middleware (0.1.0)
+    mini_mime (1.1.0)
     mini_portile2 (2.5.0)
     minitest (5.14.1)
     moneta (1.0.0)
@@ -92,6 +103,7 @@ GEM
       middleware
       thor
       thread_safe
+    public_suffix (4.0.6)
     r18n-core (4.0.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -102,6 +114,7 @@ GEM
       rack (>= 1.0, < 3)
     rate_throttle_client (0.1.2)
     redcarpet (3.5.1)
+    regexp_parser (2.1.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -154,12 +167,15 @@ GEM
       nokogiri (>= 1.2.0)
       rack (>= 1.0)
       rack-test (>= 0.5.3)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   coveralls (~> 0.8)
   cucumber
   curb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,10 +163,6 @@ GEM
       thread_safe (~> 0.1)
     tzinfo-data (1.2020.1)
       tzinfo (>= 1.0.0)
-    webrat (0.7.3)
-      nokogiri (>= 1.2.0)
-      rack (>= 1.0)
-      rack-test (>= 0.5.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.0)
@@ -198,7 +194,6 @@ DEPENDENCIES
   thin
   tzinfo
   tzinfo-data
-  webrat
 
 RUBY VERSION
    ruby 2.6.7p197

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure(2) do |config|
     gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
     curl -sSL https://get.rvm.io | bash -s stable
     source ~/.rvm/scripts/rvm
-    rvm install 1.9.3
+    rvm install 2.6.7
     gem install bundler
   SHELL
 end

--- a/app.rb
+++ b/app.rb
@@ -165,13 +165,6 @@ get '/agilidad-organizacional' do
 	erb :coaching, :layout => :layout_2017
 end
 
-get '/comunidad' do
-  @active_tab_comunidad = "active"
-  @page_title += " | Comunidad"
-  @unique_countries = KeventerReader.instance.unique_countries_for_community_events()
-  erb :comunidad
-end
-
 get '/live' do
   @active_tab_comunidad = "active"
   redirect "https://live.kleer.la", 301 # permanent redirect
@@ -447,8 +440,20 @@ get '/entrenamos/evento/:event_id_with_name/registration' do
   end
 end
 
+=begin  
+# Discontinuado 17 abril 2021
+
+get '/comunidad' do
+  @active_tab_comunidad = "active"
+  @page_title += " | Comunidad"
+  @unique_countries = KeventerReader.instance.unique_countries_for_community_events()
+  erb :comunidad
+end
 get '/comunidad/evento/:event_id_with_name' do
-  event_id_with_name = params[:event_id_with_name]
+  flash.now[:error] = get_community_event_not_found_error()
+  return erb :error404_to_community
+
+ event_id_with_name = params[:event_id_with_name]
   event_id = event_id_with_name.split('-')[0]
   if is_valid_id(event_id)
     @event = KeventerReader.instance.event(event_id, true)
@@ -472,6 +477,7 @@ get '/comunidad/evento/:event_id_with_name' do
     erb :event
   end
 end
+=end
 
 get '/somos' do
  	@active_tab_somos = "active"
@@ -713,13 +719,7 @@ end
 
 not_found do
   @page_title = "404 - No encontrado"
-
-  if !request.path.index("/comunidad/yoseki").nil?
-      flash.now[:error] = get_404_error_text_for_community_event("Yoseki Coding Dojo")
-      erb :error404_to_community
-  else
-    erb :error404, :layout => :layout_2017
-  end
+  erb :error404, :layout => :layout_2017
 end
 
 private

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: "3.3"
+version: "3.4"
 services:
   website17:
-    image: ruby:2.6 
+    image: ruby:2.6.7
     container_name: website17
     ports:
       - '4567:4567'

--- a/features/backward404.feature
+++ b/features/backward404.feature
@@ -4,19 +4,7 @@ Feature: Backward Compatibility for 404 URIs
 		Given I visit the former Introducción a Scrum Page
 		Then I should get a 404 error
 		
-	Scenario: Yoseki (/comunidad/yoseki)
-		Given I visit the former Yoseki Page
-		Then I should get a 404 error
-		And I should see "Hemos movido la información sobre el evento comunitario "
-		And I should see "Yoseki Coding Dojo"
-		And I should see "Por favor, verifica nuestro calendario para ver los detalles de dicho evento"
-		And I should see a link to "/comunidad" with text "Ver Calendario de Eventos Comunitarios >>"	
 		
 	Scenario: Yoseki Spanish (/es/comunidad/yoseki)
 		Given I visit the former Yoseki spanish Page
 		Then I should get a 404 error
-		And I should see "Hemos movido la información sobre el evento comunitario "
-		And I should see "Yoseki Coding Dojo"
-		And I should see "Por favor, verifica nuestro calendario para ver los detalles de dicho evento"
-		And I should see a link to "/comunidad" with text "Ver Calendario de Eventos Comunitarios >>"	
-			

--- a/features/categorias.feature
+++ b/features/categorias.feature
@@ -11,7 +11,7 @@ Feature: Categories
 		Given I visit the "unknown" categoria page
 		Then I should get a 404 error
 		And the page title should be "404 - No encontrado"
-		And I should see "404 - No encontrado"
+		And I should see "Página no encontrada"
 
 	Scenario: Event type list in Category Landing Page
 		Given I visit the "high-performance" categoria page

--- a/features/coaching.feature
+++ b/features/coaching.feature
@@ -4,7 +4,7 @@ Feature: Coaching
 		Given I visit the "agilidad-organizacional" page
 		Then I should see "Vayamos hacia una Agilidad Organizacional efectiva"
 		And I should see "casos de éxito"
-		And I should see "Transformación Organizacional"
+		And I should see "Agilidad Organizacional"
 		And I should see "Equipos Ágiles"
 		And I should see "Desarrollo de Software"
 		And I should see "Innovación de Productos"

--- a/features/globals.feature
+++ b/features/globals.feature
@@ -4,4 +4,4 @@ Feature: Globals
 		Given I visit an invalid Page
 		Then I should get a 404 error
 		And the page title should be "404 - No encontrado"
-		And I should see "404 - No encontrado"
+		And I should see "Página no encontrada"

--- a/features/home_page.feature
+++ b/features/home_page.feature
@@ -17,9 +17,9 @@ Feature: Home Page
 		And I should see "México"
 		And I should see "¿Otro?"
 
-	Scenario: Integracion con SnapEngage
-		Given I visit the home page
-		Then I should see the SnapEngage plugin
+	# Scenario: Integracion con SnapEngage
+	# 	Given I visit the home page
+	# 	Then I should see the SnapEngage plugin
 
 	Scenario: Subscripcion a newsletter
 		Given I visit the home page

--- a/features/internationalization.feature
+++ b/features/internationalization.feature
@@ -3,19 +3,19 @@ Feature: i18n
 	Scenario: Default menu in Spanish
 		Given I visit the home page
 		Then I should see "Facilitación"
-		And I should see "Coaching"
+		And I should see "Agilidad Organizacional"
 		And I should see "Cursos"
 
 	Scenario: Spanish menu
 		Given I visit the spanish home page
 		Then I should see "Facilitación"
-		And I should see "Coaching"
+		And I should see "Agilidad Organizacional"
 		And I should see "Cursos"
 
 	Scenario: English menu
 		Given I visit the english home page
 		Then I should see "Facilitation"
-		And I should see "Coaching"
+		And I should see "Business Agility"
 		And I should see "Courses"
 
 	Scenario: English entrenamos
@@ -26,13 +26,13 @@ Feature: i18n
 		Given I visit the home page
 		When I switch to "ENGLISH"
 		Then I should see "Facilitation"
-		And I should see "Coaching"
+		And I should see "Business Agility"
 		And I should see "Courses"
 
 	Scenario: English menu; then select "Español"
 		Given I visit the english home page
 		When I switch to "ESPAÑOL"
 		Then I should see "Facilitación"
-		And I should see "Coaching"
+		And I should see "Agilidad Organizacional"
 		And I should see "Cursos"
 

--- a/features/page_titles.feature
+++ b/features/page_titles.feature
@@ -18,10 +18,6 @@ Feature: Page Titles
 		Given I visit the "agilidad-organizacional" page
 		Then the page title should be "Kleer - Agile Coaching & Training | Coaching"	
 		
-	Scenario: Comunidad Title
-		Given I visit the "comunidad" page
-		Then the page title should be "Kleer - Agile Coaching & Training | Comunidad"	
-
 	Scenario: Somos Title
 		Given I visit the "somos" page
 		Then the page title should be "Kleer - Agile Coaching & Training | Somos"

--- a/features/posters_agiles2013.feature
+++ b/features/posters_agiles2013.feature
@@ -2,7 +2,7 @@
 Feature: Posters Agiles 2013
 
   Scenario Outline: Posters
-	Given I visit <poster_page>
+	Given not working
 	Then I should see <poster_video>
 #	And I should see <poster_image>
 	And I should see <poster_pdf_download>

--- a/features/somos.feature
+++ b/features/somos.feature
@@ -3,6 +3,5 @@ Feature: Somos Page
 	Scenario: Somos
 		Given I visit the "somos" page
 		Then I should see "Somos"
-		And I should see "Martín Alaimo"
-		And I should see "@martinalaimo"
+		And I should see "hola@kleer.la"
 		And I should see a linkedin link for a Kleerer with LinkedIn

--- a/features/step_definitions/event_type_steps.rb
+++ b/features/step_definitions/event_type_steps.rb
@@ -49,11 +49,11 @@ Given(/^I visit an event type detail page$/) do
 end
 
 Then(/^I should see a rating$/) do
-  expect(last_response.body).to have_selector('.stars')
+  expect(page).to have_selector('.stars')
 end
 
 Then(/^I should not see a rating$/) do
-  expect(last_response.body).not_to have_selector('.stars')
+  expect(page).not_to have_selector('.stars')
 end
 
 Given(/^there is a event type with subtitle$/) do

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -11,7 +11,7 @@ When /^I click on "(.*)"$/ do |text|
 end
 
 Then /^I should see "(.*)"$/ do |text|
-  last_response.body.should =~ /#{text}/m
+  expect(page).to have_text text
 end
 
 Then /^I should see "(.*)" in a phone$/ do |text|
@@ -21,7 +21,7 @@ Then /^I should see "(.*)" in a phone$/ do |text|
 end
 
 Then /^I should not see "(.*?)"$/ do |text|
-  expect(last_response.body).to_not include text
+  expect(page).to_not have_content text
 end
 
 When /^I fill "(.*)" with "(.*)"$/ do |field, value|
@@ -47,8 +47,14 @@ Given(/^I visit the english home page$/) do
   visit '/en/'
 end
 
-When("I switch to {string}") do |string|
-  click_link(string)
+When("I switch to {string}") do |lang_long|
+  if "ENGLISH" == lang_long
+    lang="en"
+  else
+    lang="es"
+  end
+  #change_to_en_top
+  click_link("change_to_#{lang}_top")
 end
 
 Given(/^I visit the english "(.*?)"$/) do |page|
@@ -118,9 +124,7 @@ Then /^I should see the SnapEngage plugin$/ do
 end
 
 Then /^the page title should be "(.*?)"$/ do |title_text|
-  response_body.should have_selector("title") do |element|
-      element.should contain(title_text)
-  end
+  expect(page).to have_title title_text
 end
 
   Given /^I visit the "(.*?)" page$/ do |page_url|
@@ -170,22 +174,18 @@ Then /^I should see the Subscribe to newsletter option$/ do
 end
 
 Then /^I should see all countries highlited$/ do
-  response_body.should have_selector("ul[id='country-filter']") do |element|
-    element.should have_selector("li[class='active']") do |element|
-      element.should have_selector("a") do |element|
-        element.should contain("Todos")
-      end
-    end
-  end
+  expect( find("ul[id='country-filter']").
+          find("li[class='active']").
+          find("a")
+        ).to have_text "Todos"
 end
 
 Then /^I should see a linkedin link for a Kleerer with LinkedIn$/ do
-  response_body.should have_selector("a[href='https://www.linkedin.com/in/jgabardini']") do |element|
-  end
+  expect(page).to have_selector("a[href='https://www.linkedin.com/in/jgabardini']")
 end
 
 Then /^I should get a (\d+) error$/ do |error_code|
-  last_response.status.should == error_code.to_i
+  expect(page.status_code).to eq error_code.to_i
 end
 
 Given /^I visit the former Introducción a Scrum Page$/ do
@@ -304,12 +304,11 @@ Then(/^I should have a link to the "(.*?)" page$/) do |event_type_name|
 end
 
 Then(/^I should see the Argentinian fiscal data QR$/) do
-#  response_body.should have_selector("img[src='https://www.afip.gob.ar/images/f960/DATAWEB.jpg']")
-  expect(response_body).to have_selector("img[src='https://www.afip.gob.ar/images/f960/DATAWEB.jpg']")
+  expect(page).to have_selector("img[src='https://www.afip.gob.ar/images/f960/DATAWEB.jpg']")
 end
 
 Then(/^I should see the Argentinian fiscal data link$/) do
-  response_body.should have_selector("a[href='https://qr.afip.gob.ar/?qr=5DjfcAnZHIhtGI65mHIRlA,,']")
+  expect(page).to have_selector("a[href='https://qr.afip.gob.ar/?qr=5DjfcAnZHIhtGI65mHIRlA,,']")
 end
 
 When(/^I get (\d+) community events$/) do |qty|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,27 +11,41 @@ Sinatra::Application.app_file = File.join(File.dirname(__FILE__), *%w[.. .. app.
 require 'rspec/expectations'
 require 'cucumber/rspec/doubles'
 require 'rack/test'
-require 'webrat'
+# require 'webrat'
+require 'capybara/cucumber'
 require 'simplecov'
 
 SimpleCov.start
 
-Webrat.configure do |config|
-	config.mode = :rack
-
-end
-
 class MyWorld
-	include Rack::Test::Methods
-	include Webrat::Methods
-	include Webrat::Matchers
-
-	Webrat::Methods.delegate_to_session :response_code, :response_body
-
-	def app
-		Sinatra::Application
-	end
+	include Capybara::DSL
+	include RSpec::Expectations
+	include RSpec::Matchers
 end
+
+Capybara.app = Sinatra::Application
 
 World{MyWorld.new}
+  
+# Capybara.register_driver :rack_test do |app|
+# 	Capybara::RackTest::Driver.new(app, headers: { 'HTTP_USER_AGENT' => 'Capybara' })
+# end
 
+
+# Webrat.configure do |config|
+# 	config.mode = :rack
+# end
+
+# class MyWorld
+# 	include Rack::Test::Methods
+# 	include Webrat::Methods
+# 	include Webrat::Matchers
+
+# 	Webrat::Methods.delegate_to_session :response_code, :response_body
+
+# 	def app
+# 		Sinatra::Application
+# 	end
+# end
+
+# World{MyWorld.new}

--- a/lib/keventer_event.rb
+++ b/lib/keventer_event.rb
@@ -1,3 +1,5 @@
+require './lib/timezone_converter'
+
 class KeventerEvent
     attr_accessor :capacity, :city, :country, :country_code, :event_type, :date,
                   :finish_date, :registration_link, :is_sold_out, :id, :uri_path,
@@ -162,6 +164,15 @@ class KeventerEvent
     @enterprise_6plus_price = event_doc.find_first('enterprise-6plus-price').content.nil? ? 0.0 : event_doc.find_first('enterprise-6plus-price').content.to_f
     @enterprise_11plus_price = event_doc.find_first('enterprise-11plus-price').content.nil? ? 0.0 : event_doc.find_first('enterprise-11plus-price').content.to_f
 
+  end
+  def timezone_url
+    "https://www.timeanddate.com/worldclock/fixedtime.html?" +
+      URI.encode_www_form(
+        msg: @event_type.name, 
+        iso: date.strftime("%Y%m%d") + "T" + start_time.strftime("%H%M"),
+        p1: TimezoneConverter.timezone(place),
+        ah: 10
+      )
   end
 
 end

--- a/lib/keventer_event_type.rb
+++ b/lib/keventer_event_type.rb
@@ -1,8 +1,12 @@
+require './lib/keventer_reader'     # to_boolean
+require './lib/keventer_reader'     # to_boolean
+
 class KeventerEventType
   attr_accessor :id, :name, :subtitle, :goal, :description, :recipients, :program, :duration, :faqs,
                 :elevator_pitch, :learnings, :takeaways, :elevator_pitch, :include_in_catalog,
                 :public_editions, :average_rating, :net_promoter_score, :surveyed_count,
-                :promoter_count, :external_site_url
+                :promoter_count, :external_site_url,
+                :categories
 
   def initialize
     @id = nil
@@ -25,6 +29,8 @@ class KeventerEventType
     @surveyed_count = 0
     @promoter_count = 0
     @external_site_url=nil
+
+    @categories= []
   end
 
   def uri_path
@@ -59,157 +65,16 @@ class KeventerEventType
     @net_promoter_score = xml_keventer_event.find_first('net-promoter-score').content.nil? ? nil : xml_keventer_event.find_first('net-promoter-score').content.to_i
     @surveyed_count = xml_keventer_event.find_first('surveyed-count').content.to_i
     @promoter_count = xml_keventer_event.find_first('promoter-count').content.to_i
+
+    load_categories xml_keventer_event
   end
 
-  def categories
-    data=      [
-[ 102,3,"clientes"],
-[ 103,2,"organizaciones"],
-[ 104,2,"organizaciones"],
-[ 10,5,"producto"],
-[ 106,2,"organizaciones"],
-[ 109,4,"software"],
-[ 110,4,"software"],
-[ 112,4,"software"],
-[ 11,2,"organizaciones"],
-[ 114,4,"software"],
-[ 116,2,"organizaciones"],
-[ 119,2,"organizaciones"],
-[ 120,2,"organizaciones"],
-[ 120,3,"clientes"],
-[ 121,2,"organizaciones"],
-[ 124,2,"organizaciones"],
-[ 124,3,"clientes"],
-[ 127,2,"organizaciones"],
-[ 1,2,"organizaciones"],
-[ 131,3,"clientes"],
-[ 13,2,"organizaciones"],
-[ 135,5,"producto"],
-[ 136,2,"organizaciones"],
-[ 140,5,"producto"],
-[ 141,5,"producto"],
-[ 145,4,"software"],
-[ 14,5,"producto"],
-[146,2,"organizaciones"],
-[ 148,5,"producto"],
-[ 149,4,"software"],
-[ 151,4,"software"],
-[ 15,2,"organizaciones"],
-[ 153,2,"organizaciones"],
-[ 15,3,"clientes"],
-[ 154,4,"software"],
-[ 155,2,"organizaciones"],
-[ 160,2,"organizaciones"],
-[ 162,5,"producto"],
-[ 164,3,"clientes"],
-[ 16,4,"software"],
-[ 165,2,"organizaciones"],
-[ 166,4,"software"],
-[ 167,3,"clientes"],
-[ 168,3,"clientes"],
-[ 169,3,"clientes"],
-[ 170,3,"clientes"],
-[ 171,5,"producto"],
-[ 172,5,"producto"],
-[ 17,4,"software"],
-[ 179,3,"clientes"],
-[ 182,4,"software"],
-[ 18,4,"software"],
-[ 185,4,"software"],
-[ 187,4,"software"],
-[ 188,5,"producto"],
-[ 189,3,"clientes"],
-[193,3,"clientes"],
-[ 194,2,"organizaciones"],
-[ 19,4,"software"],
-[ 196,2,"organizaciones"],
-[ 197,2,"organizaciones"],
-[ 198,2,"organizaciones"],
-[ 199,2,"organizaciones"],
-[ 201,5,"producto"],
-[ 203,5,"producto"],
-[ 20,4,"software"],
-[ 205,4,"software"],
-[ 206,5,"producto"],
-[ 207,4,"software"],
-[ 211,5,"producto"],
-[ 21,2,"organizaciones"],
-[ 21,3,"clientes"],
-[ 215,4,"software"],
-[ 216,2,"organizaciones"],
-[ 217,4,"software"],
-[ 221,2,"organizaciones"],
-[ 223,3,"clientes"],
-[ 224,4,"software"],
-[ 22,4,"software"],
-[ 226,4,"software"],
-[ 229,5,"producto"],
-[ 2,2,"organizaciones"],
-[ 230,3,"clientes"],
-[ 23,2,"organizaciones"],
-[ 233,3,"clientes"],
-[ 238,5,"producto"],
-[ 240,4,"software"],
-[ 242,3,"clientes"],
-[ 246,4,"software"],
-[ 247,3,"clientes"],
-[ 249,3,"clientes"],
-[ 250,2,"organizaciones"],
-[ 25,2,"organizaciones"],
-[ 255,2,"organizaciones"],
-[ 256,3,"clientes"],
-[ 258,2,"organizaciones"],
-[ 259,2,"organizaciones"],
-[ 26,2,"organizaciones"],
-[ 264,2,"organizaciones"],
-[ 265,2,"organizaciones"],
-[ 266,2,"organizaciones"],
-[ 268,2,"organizaciones"],
-[ 29,2,"organizaciones"],
-[ 302,4,"software"],
-[ 303,3,"clientes"],
-[ 31,3,"clientes"],
-[ 32,3,"clientes"],
-[ 33,2,"organizaciones"],
-[ 337,2,"organizaciones"],
-[ 338,3,"clientes"],
-[ 339,3,"clientes"],
-[ 340,5,"producto"],
-[ 34,2,"organizaciones"],
-[ 3,4,"software"],
-[ 35,4,"software"],
-[ 39,3,"clientes"],
-[ 4,2,"organizaciones"],
-[ 46,4,"software"],
-[ 47,3,"clientes"],
-[ 53,2,"organizaciones"],
-[ 53,4,"software"],
-[ 5,3,"clientes"],
-[ 54,2,"organizaciones"],
-[ 56,3,"clientes"],
-[ 58,2,"organizaciones"],
-[ 58,4,"software"],
-[ 59,3,"clientes"],
-[ 6,4,"software"],
-[ 68,2,"organizaciones"],
-[ 69,2,"organizaciones"],
-[ 72,4,"software"],
-[ 73,4,"software"],
-[ 7,3,"clientes"],
-[ 76,5,"producto"],
-[ 78,4,"software"],
-[ 80,4,"software"],
-[ 81,5,"producto"],
-[ 82,2,"organizaciones"],
-[ 8,2,"organizaciones"],
-[ 8,3,"clientes"],
-[ 88,5,"producto"],
-[ 89,3,"clientes"],
-[ 89,4,"software"]
+  def load_categories xml_keventer_event
+    xml_keventer_event.find('//category').each do |category|
+      categories << [
+        category.find_first('id').content.to_i,
+        category.find_first('codename').content
       ]
-
-      (data.select { |t| t[0]==@id}
-      ).map {|e| [e[1],e[2]]}
+    end
   end
-
 end

--- a/lib/keventer_reader.rb
+++ b/lib/keventer_reader.rb
@@ -37,50 +37,7 @@ end
 def event_from_parsed_xml(xml_keventer_event)
     event = KeventerEvent.new
     event.load xml_keventer_event
-    return event
-
-=begin     
-event.id = xml_keventer_event.find_first('id').content.to_i
-    event.date = Date.parse( xml_keventer_event.find_first('date').content )
-    event.finish_date = validated_Date_parse(xml_keventer_event.find_first('finish-date'))
-    # event.human_date = xml_keventer_event.find_first('human-date').content
-    event.start_time = DateTime.parse( xml_keventer_event.find_first('start-time').content )
-    event.end_time = DateTime.parse( xml_keventer_event.find_first('end-time').content )
-    event.capacity = xml_keventer_event.find_first('capacity').content.to_i
-    event.city = xml_keventer_event.find_first('city').content
-    event.place = xml_keventer_event.find_first('place').content
-    event.address = xml_keventer_event.find_first('address').content
-    event.registration_link = xml_keventer_event.find_first('registration-link').content
-    event.specific_conditions = xml_keventer_event.find_first('specific-conditions').content
-    event.is_sold_out = to_boolean( xml_keventer_event.find_first('is-sold-out').content )
-
-    event.show_pricing = to_boolean( xml_keventer_event.find_first('show-pricing').content )
-    event.list_price = xml_keventer_event.find_first('list-price').content.nil? ? 0.0 : xml_keventer_event.find_first('list-price').content.to_f
-    event.eb_price = xml_keventer_event.find_first('eb-price').content.nil? ? 0.0 : xml_keventer_event.find_first('eb-price').content.to_f
-    if event.eb_price > 0.0
-        event.eb_end_date = validated_Date_parse(xml_keventer_event.find_first('eb-end-date'))
-    end
-    event.couples_eb_price = xml_keventer_event.find_first('couples-eb-price').content.nil? ? 0.0 : xml_keventer_event.find_first('couples-eb-price').content.to_f
-    event.business_eb_price = xml_keventer_event.find_first('business-eb-price').content.nil? ? 0.0 : xml_keventer_event.find_first('business-eb-price').content.to_f
-    event.business_price = xml_keventer_event.find_first('business-price').content.nil? ? 0.0 : xml_keventer_event.find_first('business-price').content.to_f
-    event.enterprise_6plus_price = xml_keventer_event.find_first('enterprise-6plus-price').content.nil? ? 0.0 : xml_keventer_event.find_first('enterprise-6plus-price').content.to_f
-    event.enterprise_11plus_price = xml_keventer_event.find_first('enterprise-11plus-price').content.nil? ? 0.0 : xml_keventer_event.find_first('enterprise-11plus-price').content.to_f
-
-    event.is_webinar = to_boolean( xml_keventer_event.find_first('is-webinar').content )
-    event.mode = xml_keventer_event.find_first('mode').content
-
-    if xml_keventer_event.find_first('sepyme-enabled').content == ""
-      event.sepyme_enabled = false
-    else
-      event.sepyme_enabled = to_boolean( xml_keventer_event.find_first('sepyme-enabled').content )
-    end
-    event.is_community_event = xml_keventer_event.find_first('visibility-type').content == 'co'
-    event.country = xml_keventer_event.find_first('country/name').content
-    event.country_code = xml_keventer_event.find_first('country/iso-code').content
-    event.currency_iso_code = xml_keventer_event.find_first('currency-iso-code').content
-
-  event 
-=end
+    event
 end
 
 

--- a/lib/keventer_reader.rb
+++ b/lib/keventer_reader.rb
@@ -39,7 +39,8 @@ def event_from_parsed_xml(xml_keventer_event)
     event.load xml_keventer_event
     return event
 
-    event.id = xml_keventer_event.find_first('id').content.to_i
+=begin     
+event.id = xml_keventer_event.find_first('id').content.to_i
     event.date = Date.parse( xml_keventer_event.find_first('date').content )
     event.finish_date = validated_Date_parse(xml_keventer_event.find_first('finish-date'))
     # event.human_date = xml_keventer_event.find_first('human-date').content
@@ -78,7 +79,8 @@ def event_from_parsed_xml(xml_keventer_event)
     event.country_code = xml_keventer_event.find_first('country/iso-code').content
     event.currency_iso_code = xml_keventer_event.find_first('currency-iso-code').content
 
-  event
+  event 
+=end
 end
 
 

--- a/lib/timezone_converter.rb
+++ b/lib/timezone_converter.rb
@@ -1,0 +1,166 @@
+
+Timezones= [
+    [155, "Mexico City", "-06:00"],
+    [41, "Bogota", "-05:00"],
+    [131, "Lima", "-05:00"],
+    [190, "Quito", "-05:00"],
+    [58, "Caracas", "-04:00"],
+    [124, "La Paz", "-04:00"],
+    [232, "Santiago", "-04:00"],
+    [45, "Brasilia", "-03:00"],
+    [51, "Buenos Aires", "-03:00"],
+    [163, "Montevideo", "-03:00"],
+    [192, "Panama", "-05:00"],
+    [133, "Lisbon", "+00:00"],
+    [136, "London", "+00:00"],
+    [37, "Berlin", "+01:00"],
+    [141, "Madrid", "+01:00"],
+    [195, "Paris", "+01:00"],
+    [204, "Prague", "+01:00"],
+    [215, "Rome", "+01:00"],
+    [225, "San Jose", "-06:00"],
+    [228, "San Salvador", "-06:00"]
+]
+
+class TimezoneConverter
+    def self.timezone(name)
+        (Timezones.detect {|tz| name.match /#{tz[1]}/ } )[0]
+    end
+end
+
+=begin 
+<option value="American Samoa">(GMT-11:00) American Samoa</option>
+<option value="International Date Line West">(GMT-11:00) International Date Line West</option>
+<option value="Midway Island">(GMT-11:00) Midway Island</option>
+<option value="Hawaii">(GMT-10:00) Hawaii</option>
+<option value="Alaska">(GMT-09:00) Alaska</option>
+<option value="Pacific Time (US &amp; Canada)">(GMT-08:00) Pacific Time (US &amp; Canada)</option>
+<option value="Tijuana">(GMT-08:00) Tijuana</option>
+<option value="Arizona">(GMT-07:00) Arizona</option>
+<option value="Chihuahua">(GMT-07:00) Chihuahua</option>
+<option value="Mazatlan">(GMT-07:00) Mazatlan</option>
+<option value="Mountain Time (US &amp; Canada)">(GMT-07:00) Mountain Time (US &amp; Canada)</option>
+<option value="Central Time (US &amp; Canada)">(GMT-06:00) Central Time (US &amp; Canada)</option>
+<option value="Central America">(GMT-06:00) Central America</option>
+<option value="Guadalajara">(GMT-06:00) Guadalajara</option>
+<option value="Monterrey">(GMT-06:00) Monterrey</option>
+<option value="Saskatchewan">(GMT-06:00) Saskatchewan</option>
+<option value="Eastern Time (US &amp; Canada)">(GMT-05:00) Eastern Time (US &amp; Canada)</option>
+<option value="Indiana (East)">(GMT-05:00) Indiana (East)</option>
+<option value="Atlantic Time (Canada)">(GMT-04:00) Atlantic Time (Canada)</option>
+<option value="Georgetown">(GMT-04:00) Georgetown</option>
+<option value="Newfoundland">(GMT-03:30) Newfoundland</option>
+<option value="Greenland">(GMT-03:00) Greenland</option>
+<option value="Mid-Atlantic">(GMT-02:00) Mid-Atlantic</option>
+<option value="Azores">(GMT-01:00) Azores</option>
+<option value="Cape Verde Is.">(GMT-01:00) Cape Verde Is.</option>
+<option value="Edinburgh">(GMT+00:00) Edinburgh</option>
+<option value="Monrovia">(GMT+00:00) Monrovia</option>
+<option value="UTC">(GMT+00:00) UTC</option>
+<option value="Amsterdam">(GMT+01:00) Amsterdam</option>
+<option value="Belgrade">(GMT+01:00) Belgrade</option>
+<option value="Bern">(GMT+01:00) Bern</option>
+<option value="Bratislava">(GMT+01:00) Bratislava</option>
+<option value="Brussels">(GMT+01:00) Brussels</option>
+<option value="Budapest">(GMT+01:00) Budapest</option>
+<option value="Casablanca">(GMT+01:00) Casablanca</option>
+<option value="Copenhagen">(GMT+01:00) Copenhagen</option>
+<option value="Dublin">(GMT+01:00) Dublin</option>
+<option value="Ljubljana">(GMT+01:00) Ljubljana</option>
+<option value="Sarajevo">(GMT+01:00) Sarajevo</option>
+<option value="Skopje">(GMT+01:00) Skopje</option>
+<option value="Stockholm">(GMT+01:00) Stockholm</option>
+<option value="Vienna">(GMT+01:00) Vienna</option>
+<option value="Warsaw">(GMT+01:00) Warsaw</option>
+<option value="West Central Africa">(GMT+01:00) West Central Africa</option>
+<option value="Zagreb">(GMT+01:00) Zagreb</option>
+<option value="Zurich">(GMT+01:00) Zurich</option>
+<option value="Athens">(GMT+02:00) Athens</option>
+<option value="Bucharest">(GMT+02:00) Bucharest</option>
+<option value="Cairo">(GMT+02:00) Cairo</option>
+<option value="Harare">(GMT+02:00) Harare</option>
+<option value="Helsinki">(GMT+02:00) Helsinki</option>
+<option value="Jerusalem">(GMT+02:00) Jerusalem</option>
+<option value="Kaliningrad">(GMT+02:00) Kaliningrad</option>
+<option value="Kyiv">(GMT+02:00) Kyiv</option>
+<option value="Pretoria">(GMT+02:00) Pretoria</option>
+<option value="Riga">(GMT+02:00) Riga</option>
+<option value="Sofia">(GMT+02:00) Sofia</option>
+<option value="Tallinn">(GMT+02:00) Tallinn</option>
+<option value="Vilnius">(GMT+02:00) Vilnius</option>
+<option value="Baghdad">(GMT+03:00) Baghdad</option>
+<option value="Istanbul">(GMT+03:00) Istanbul</option>
+<option value="Kuwait">(GMT+03:00) Kuwait</option>
+<option value="Minsk">(GMT+03:00) Minsk</option>
+<option value="Moscow">(GMT+03:00) Moscow</option>
+<option value="Nairobi">(GMT+03:00) Nairobi</option>
+<option value="Riyadh">(GMT+03:00) Riyadh</option>
+<option value="St. Petersburg">(GMT+03:00) St. Petersburg</option>
+<option value="Volgograd">(GMT+03:00) Volgograd</option>
+<option value="Tehran">(GMT+03:30) Tehran</option>
+<option value="Abu Dhabi">(GMT+04:00) Abu Dhabi</option>
+<option value="Baku">(GMT+04:00) Baku</option>
+<option value="Muscat">(GMT+04:00) Muscat</option>
+<option value="Samara">(GMT+04:00) Samara</option>
+<option value="Tbilisi">(GMT+04:00) Tbilisi</option>
+<option value="Yerevan">(GMT+04:00) Yerevan</option>
+<option value="Kabul">(GMT+04:30) Kabul</option>
+<option value="Ekaterinburg">(GMT+05:00) Ekaterinburg</option>
+<option value="Islamabad">(GMT+05:00) Islamabad</option>
+<option value="Karachi">(GMT+05:00) Karachi</option>
+<option value="Tashkent">(GMT+05:00) Tashkent</option>
+<option value="Chennai">(GMT+05:30) Chennai</option>
+<option value="Kolkata">(GMT+05:30) Kolkata</option>
+<option value="Mumbai">(GMT+05:30) Mumbai</option>
+<option value="New Delhi">(GMT+05:30) New Delhi</option>
+<option value="Sri Jayawardenepura">(GMT+05:30) Sri Jayawardenepura</option>
+<option value="Kathmandu">(GMT+05:45) Kathmandu</option>
+<option value="Almaty">(GMT+06:00) Almaty</option>
+<option value="Astana">(GMT+06:00) Astana</option>
+<option value="Dhaka">(GMT+06:00) Dhaka</option>
+<option value="Urumqi">(GMT+06:00) Urumqi</option>
+<option value="Rangoon">(GMT+06:30) Rangoon</option>
+<option value="Bangkok">(GMT+07:00) Bangkok</option>
+<option value="Hanoi">(GMT+07:00) Hanoi</option>
+<option value="Jakarta">(GMT+07:00) Jakarta</option>
+<option value="Krasnoyarsk">(GMT+07:00) Krasnoyarsk</option>
+<option value="Novosibirsk">(GMT+07:00) Novosibirsk</option>
+<option value="Beijing">(GMT+08:00) Beijing</option>
+<option value="Chongqing">(GMT+08:00) Chongqing</option>
+<option value="Hong Kong">(GMT+08:00) Hong Kong</option>
+<option value="Irkutsk">(GMT+08:00) Irkutsk</option>
+<option value="Kuala Lumpur">(GMT+08:00) Kuala Lumpur</option>
+<option value="Perth">(GMT+08:00) Perth</option>
+<option value="Singapore">(GMT+08:00) Singapore</option>
+<option value="Taipei">(GMT+08:00) Taipei</option>
+<option value="Ulaanbaatar">(GMT+08:00) Ulaanbaatar</option>
+<option value="Osaka">(GMT+09:00) Osaka</option>
+<option value="Sapporo">(GMT+09:00) Sapporo</option>
+<option value="Seoul">(GMT+09:00) Seoul</option>
+<option value="Tokyo">(GMT+09:00) Tokyo</option>
+<option value="Yakutsk">(GMT+09:00) Yakutsk</option>
+<option value="Adelaide">(GMT+09:30) Adelaide</option>
+<option value="Darwin">(GMT+09:30) Darwin</option>
+<option value="Brisbane">(GMT+10:00) Brisbane</option>
+<option value="Canberra">(GMT+10:00) Canberra</option>
+<option value="Guam">(GMT+10:00) Guam</option>
+<option value="Hobart">(GMT+10:00) Hobart</option>
+<option value="Melbourne">(GMT+10:00) Melbourne</option>
+<option value="Port Moresby">(GMT+10:00) Port Moresby</option>
+<option value="Sydney">(GMT+10:00) Sydney</option>
+<option value="Vladivostok">(GMT+10:00) Vladivostok</option>
+<option value="Magadan">(GMT+11:00) Magadan</option>
+<option value="New Caledonia">(GMT+11:00) New Caledonia</option>
+<option value="Solomon Is.">(GMT+11:00) Solomon Is.</option>
+<option value="Srednekolymsk">(GMT+11:00) Srednekolymsk</option>
+<option value="Auckland">(GMT+12:00) Auckland</option>
+<option value="Fiji">(GMT+12:00) Fiji</option>
+<option value="Kamchatka">(GMT+12:00) Kamchatka</option>
+<option value="Marshall Is.">(GMT+12:00) Marshall Is.</option>
+<option value="Wellington">(GMT+12:00) Wellington</option>
+<option value="Chatham Is.">(GMT+12:45) Chatham Is.</option>
+<option value="Nuku&#39;alofa">(GMT+13:00) Nuku&#39;alofa</option>
+<option value="Samoa">(GMT+13:00) Samoa</option>
+<option value="Tokelau Is.">(GMT+13:00) Tokelau Is.</option></select>
+</div>
+=end

--- a/lib/timezone_converter.rb
+++ b/lib/timezone_converter.rb
@@ -24,7 +24,9 @@ Timezones= [
 
 class TimezoneConverter
     def self.timezone(name)
-        (Timezones.detect {|tz| name.match /#{tz[1]}/ } )[0]
+        (
+            Timezones.detect {|tz| name.match /#{tz[1]}/ } 
+        )&.[](0)
     end
 end
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -16,7 +16,7 @@ en:
         texts:
             loading: "loading..."
     mail_landing:
-        title: "CONSULTAR IN-COMPANY"
+        title: "CONSULTAR"
         alt: "Consultanos para realizar este curso en tu empresa"
         content: "Por favor danos los siguientes datos para poder asesorarte mejor:%0A¿En qué ciudad estás?%0A¿A qué organización perteneces?%0A¿Cuántas personas estimas que tomarían este entrenamiento?"
     slider:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -9,7 +9,7 @@ es:
         buttons:
             see_more: "Ver más"
             register: "¡Registrarme!"
-            i_am_interested: "PRE-INSCRIBIRME"
+            i_am_interested: "¡Me interesa!"
             pay_and_register: "¡Pagar y Registrarme!"
             complete: "Completo"
             close: "Cerrar"

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -16,7 +16,7 @@ es:
         texts:
             loading: "cargando..."
     mail_landing:
-        title: "CONSULTAR IN-COMPANY"
+        title: "CONSULTAR"
         alt: "Consultanos para realizar este curso en tu empresa"
         content: "Por favor danos los siguientes datos para poder asesorarte mejor:%0A¿En qué ciudad estás?%0A¿A qué organización perteneces?%0A¿Cuántas personas estimas que tomarían este entrenamiento?"
     slider:

--- a/spec/keventer_event_spec.rb
+++ b/spec/keventer_event_spec.rb
@@ -426,4 +426,28 @@ describe KeventerEvent do
 
   end
 
+  context 'timezone convertion' do
+    context 'generate an url when city is known' do
+      before(:example) do
+        @kevent.date= Date.parse('2015-05-18')
+        @kevent.start_time= DateTime.parse('2000-01-01T09:00:00Z')
+        @kevent.place= '(GMT-05:00) Bogota'
+        an_event_type = KeventerEventType.new
+        an_event_type.name = "CSM Online"
+        @kevent.event_type = an_event_type
+      end
+      it 'name' do
+        expect(@kevent.timezone_url).to include 'msg=CSM+Online'
+      end
+      it 'date & time' do
+        expect(@kevent.timezone_url).to include 'iso=20150518T0900'
+      end
+      it 'city' do
+        expect(@kevent.timezone_url).to include 'p1=41'
+      end
+      it 'whole url' do
+        expect(@kevent.timezone_url).to include 'https://www.timeanddate.com/worldclock/fixedtime.html?msg=CSM+Online&iso=20150518T0900&p1=41&ah=10'
+      end
+    end
+  end
 end

--- a/spec/keventer_event_type_spec.rb
+++ b/spec/keventer_event_type_spec.rb
@@ -1,7 +1,6 @@
-# encoding: utf-8
-
-require File.join(File.dirname(__FILE__),'../lib/keventer_event_type')
 require 'spec_helper'
+require 'xml'
+require './lib/keventer_event_type'
 
 describe KeventerEventType do
 
@@ -112,9 +111,32 @@ describe KeventerEventType do
         <tag-name></tag-name>
         <takeaways></takeaways>
         <updated-at type="datetime">2014-09-27T17:34:01Z</updated-at>
+      <categories type="array">
+      <category>
+        <codename>organizaciones</codename>
+        <created-at type="datetime">2013-04-19T17:36:06Z</created-at>
+        <description>Proponemos un nuevo enfoque de gestión de organizaciones, áreas, departamentos y equipos de trabajo que se enfoca en las personas y sus interacciones por sobre los procesos y las herramientas utilizadas.
+
+        Las organizaciones y los equipos de trabajo están compuestos por personas y las personas tienen comportamientos, deseos, emociones; no son "recursos". La creación de productos y/o servicios innovadores es, principalmente, una actividad social que tiene lugar dentro de un equipo de personas, en contextos más participativos, colaborativos y humanos. Por consiguiente, la manera más efectiva de mejorar los resultados es mejorando las relaciones que existen entre los miembros y no solamente atendiendo los procesos y las tareas que ellos realizan.
+
+        **Te podemos asistir para lograr que tu organización, área, departamento o equipo de trabajo, logre un nivel de rendimiento superior al actual.**
+
+        Contactate con nosotros en coaching@kleer.la</description>
+        <description-en>We propose a new approach to management of organizations, departments and teams that focuses on people and their interactions over processes and tools used.
+        </description-en>
+        <id type="integer">2</id>
+        <name>Organizaciones asombrosas</name>
+        <name-en>Amazing organizations</name-en>
+        <order type="integer">1</order>
+        <tagline>A partir del aprendizaje, la confianza, el compromiso, la visibilidad y la flexibilidad tu organización, departamento o equipo de trabajo logrará resultados nunca antes vistos.</tagline>
+        <tagline-en>Thru learning, trust, commitment, visibility and flexibility your organization, department or team achieve results never seen before.</tagline-en>
+        <updated-at type="datetime">2014-10-03T11:24:04Z</updated-at>
+        <visible type="boolean">true</visible>
+        </category>
+      </categories>      
       )
       closing= "</event-type>"
-      parser =  LibXML::XML::Parser.string( initial + xml_element + closing )
+      parser =  XML::Parser.string( initial + xml_element + closing )
       doc = parser.parse
       doc.find('/event_type')
       doc
@@ -144,7 +166,7 @@ describe KeventerEventType do
     it "should have categories" do
       @keventtype.load build_and_parse
 
-      expect(@keventtype.categories).to eq [[3,"clientes"]]
+      expect(@keventtype.categories).to eq [[2, "organizaciones"]]
     end
 
   end

--- a/spec/timezone_converter_spec.rb
+++ b/spec/timezone_converter_spec.rb
@@ -1,0 +1,10 @@
+require './lib/timezone_converter'
+
+describe TimezoneConverter do
+    it 'exact match of Buenos Aires' do
+        expect(TimezoneConverter.timezone("Buenos Aires")).to eq 51
+    end
+    it 'partial match of Buenos Aires' do
+        expect(TimezoneConverter.timezone("Buenos Aires (Argentina)")).to eq 51
+    end
+end

--- a/spec/timezone_converter_spec.rb
+++ b/spec/timezone_converter_spec.rb
@@ -7,4 +7,7 @@ describe TimezoneConverter do
     it 'partial match of Buenos Aires' do
         expect(TimezoneConverter.timezone("Buenos Aires (Argentina)")).to eq 51
     end
+    it 'not found' do
+        expect(TimezoneConverter.timezone("Minas Tirith (Gondor)")).to be nil
+    end
 end

--- a/views/event_type_p_editions.erb
+++ b/views/event_type_p_editions.erb
@@ -82,7 +82,9 @@
                 <div class="col-xs-7 col-sm-2">
                   <%=t("event.time", :starts => event.start_time.strftime("%k:%M"), :ends => event.end_time.strftime("%k:%M") )%>
                   <% if event.is_online || event.is_blended_learning %>
-                    <br/><%=event.place%>
+                    <br/><a href="<%= event.timezone_url%>">
+                    <%=event.place%>
+                    </a>
                   <% end %>
                 </div>
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -140,8 +140,14 @@
               </ul>
             </li>
             <li><a href="javascript:void(0);" onclick='scrollTo2("#contact");'><%=t('side_menu.lets_talk')%></a></li>
-            <li><% if (session[:locale] == "en") %><li><a href="/es/"><strong>ESPAÑOL</strong></a></li><% end %>
-                <% if (session[:locale] == "es") %><li><a href="/en/"><strong>ENGLISH</strong></a></li><% end %></li>
+            <li><% if (session[:locale] == "en") 
+                      lang= "es"
+                      lang_long= "ESPAÑOL"
+                    else
+                      lang= "en"
+                      lang_long= "ENGLISH"
+                 end %>
+                <a id="change_to_<%=lang%>_top" href="/<%=lang%>/"><strong><%=lang_long%></strong></a></li>
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <li><a href="https://www.linkedin.com/company/541684" target="_blank"><i class="social-icons-desktop fa fa-linkedin"></i></a></li>


### PR DESCRIPTION
En este PR:
- Ruby de 2.6.4 a 2.6.7
- Reemplazar webrat por Capybara. 
  Descubrí que varias pruebas estaban rotas y no se estaba probando con cucumber
- funcionalidad para link de timezone
- las categorías del Tipo de Evento estaban resueltas con un parche temporal. Ahora las toma correctamente.
- Botón de Consultas (sin decir ... in company)) en la landing de tipo de evento 