### PR TITLE
Blog on reverse proxy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'tzinfo-data'
 gem 'money'
 gem 'escape_utils'
 gem 'rack-ssl-enforcer'
+gem 'rack-reverse-proxy', :require => 'rack/reverse_proxy'
 
 group :development do
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,11 @@ GEM
     rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
+    rack-proxy (0.7.0)
+      rack
+    rack-reverse-proxy (0.12.0)
+      rack (>= 1.0.0)
+      rack-proxy (~> 0.6, >= 0.6.1)
     rack-ssl-enforcer (0.2.9)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -188,6 +193,7 @@ DEPENDENCIES
   oauth
   platform-api
   prawn
+  rack-reverse-proxy
   rack-ssl-enforcer
   redcarpet
   rspec

--- a/README.md
+++ b/README.md
@@ -27,13 +27,20 @@ Docker
 ---
 
 Para desarrollar con docker
+```cli
 docker-compose run --service-ports website17 bash
 cd app
 gem install bundler:2.0.2
 bundle install
 ruby app.rb -o 0
-
+```
 
 Routes
----
+```cli
 rake routes
+```
+
+Referencias para configurar el Wordpress por reverse proxy
+* https://www.cloudanix.com/blog/wordpress-installation-on-a-subdirectory-of-an-existing-app-ruby-on-rails/
+* https://medium.com/@technoblogueur/wordpress-blog-for-ruby-on-rails-the-configuration-that-worked-for-me-a8a7a989a68d
+* https://www.netlingshq.com/blog/wordpress-with-ruby-on-rails/

--- a/app.rb
+++ b/app.rb
@@ -86,7 +86,7 @@ configure do
     reverse_proxy_options timeout: 30
     reverse_proxy_options preserve_host: true
     # reverse_proxy_options username: 'basic-auth-username', password: 'basic-auth-password'
-    reverse_proxy /^\/blog(\/.*)$/, 'https://kleer.evolucionagil.com/blog$1'
+    reverse_proxy /^\/blog-nuevo(\/.*)$/, 'https://kleer.evolucionagil.com/blog$1'
   end
 end
 
@@ -133,14 +133,14 @@ get '/es' do
   redirect "/es/", 301 # permanent redirect
 end
 
-# get '/blog' do
-#   @active_tab_blog = "active"
-#   @rss = RSS::Parser.parse('https://medium.com/feed/kleer', false)
-#   erb :blog, :layout => :layout_2017
-# end
-
 get '/blog' do
-  redirect "/blog/", 301 # permanent redirect
+  @active_tab_blog = "active"
+  @rss = RSS::Parser.parse('https://medium.com/feed/kleer', false)
+  erb :blog, :layout => :layout_2017
+end
+
+get '/blog-nuevo' do
+  redirect "/blog-nuevo/", 301 # permanent redirect
 end
 
 get '/entrenamos/:country?' do |country|

--- a/app.rb
+++ b/app.rb
@@ -83,16 +83,10 @@ configure do
   KeventerReader.build
 
   use Rack::ReverseProxy do
-    # options = { 
-    #   preserve_host: true,
-    #   username: 'basic-auth-username',
-    #   password: 'basic-auth-password',
-    #   timeout: 30
-    # }
     reverse_proxy_options timeout: 30
     reverse_proxy_options preserve_host: true
     # reverse_proxy_options username: 'basic-auth-username', password: 'basic-auth-password'
-    reverse_proxy /^\/blog(\/.*)$/, 'https://kleer.evolucionagil.com/blog$1' #, opts = options
+    reverse_proxy /^\/blog(\/.*)$/, 'https://kleer.evolucionagil.com/blog$1'
   end
 end
 
@@ -146,7 +140,7 @@ end
 # end
 
 get '/blog' do
-  redirect "https://www.kleer.la/blog/", 301 # permanent redirect
+  redirect "/blog/", 301 # permanent redirect
 end
 
 get '/entrenamos/:country?' do |country|

--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,7 @@ require 'i18n'
 require 'money'
 require 'rss'
 require 'escape_utils'
+require 'rack/reverse_proxy'
 
 require './lib/keventer_reader'
 require './lib/dt_helper'
@@ -80,6 +81,19 @@ configure do
 
   enable :sessions
   KeventerReader.build
+
+  use Rack::ReverseProxy do
+    # options = { 
+    #   preserve_host: true,
+    #   username: 'basic-auth-username',
+    #   password: 'basic-auth-password',
+    #   timeout: 30
+    # }
+    reverse_proxy_options timeout: 30
+    reverse_proxy_options preserve_host: true
+    # reverse_proxy_options username: 'basic-auth-username', password: 'basic-auth-password'
+    reverse_proxy /^\/blog(\/.*)$/, 'https://kleer.evolucionagil.com/blog$1' #, opts = options
+  end
 end
 
 before do
@@ -125,10 +139,14 @@ get '/es' do
   redirect "/es/", 301 # permanent redirect
 end
 
+# get '/blog' do
+#   @active_tab_blog = "active"
+#   @rss = RSS::Parser.parse('https://medium.com/feed/kleer', false)
+#   erb :blog, :layout => :layout_2017
+# end
+
 get '/blog' do
-  @active_tab_blog = "active"
-  @rss = RSS::Parser.parse('https://medium.com/feed/kleer', false)
-  erb :blog, :layout => :layout_2017
+  redirect "https://www.kleer.la/blog/", 301 # permanent redirect
 end
 
 get '/entrenamos/:country?' do |country|

--- a/app.rb
+++ b/app.rb
@@ -86,7 +86,7 @@ configure do
     reverse_proxy_options timeout: 30
     reverse_proxy_options preserve_host: true
     # reverse_proxy_options username: 'basic-auth-username', password: 'basic-auth-password'
-    reverse_proxy /^\/blog-nuevo(\/.*)$/, 'https://kleer.evolucionagil.com/blog$1'
+    reverse_proxy /^\/blog-nuevo(\/.*)$/, 'https://kleer.evolucionagil.com/blog-nuevo$1'
   end
 end
 


### PR DESCRIPTION
Nuevo end-point en /blog-nuevo/ configurado como reverse proxy a https://kleer.evoluciónagil.com/blog-nuevo de manera todo el contenido del blog se ve en /blog-nuevo/

Hemos configurado el blog https://kleer.evolucionagil.com/blog-nuevo con password de front-end de manera que no sea indexado por google directamente. Luego configuraremos el reverse-proxy con la clave para que no la pida al ingresar a /blog-nuevo/ pero por ahora nos parece que es mejor que la pida.