### PR TITLE
Add booking system with consultant scheduling

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -35,6 +35,7 @@ require './controllers/news_controller'
 require './controllers/certificates_controller'
 require './controllers/podcasts_controller'
 require './controllers/event_controller'
+require './controllers/bookings_controller'
 
 include MetaTags
 include Recaptcha::Adapters::ViewMethods

--- a/controllers/bookings_controller.rb
+++ b/controllers/bookings_controller.rb
@@ -1,0 +1,165 @@
+require './lib/json_api'
+require './lib/services/booking_token'
+require './lib/services/mailer'
+require './lib/models/service_area_v3'
+
+include Recaptcha::Adapters::ControllerMethods
+
+get %r{/agendar/([^/]+)} do |slug|
+  service_area = ServiceAreaV3.create_keventer(slug)
+  return status 404 if service_area.nil?
+
+  # Fetch consultants for this service area
+  consultants = []
+  has_consultants = false
+  begin
+    response = JsonAPI.new(KeventerAPI.service_area_consultants_url(slug))
+    if response.ok? && response.doc.is_a?(Array) && !response.doc.empty?
+      consultants = response.doc
+      has_consultants = true
+    end
+  rescue StandardError
+    # If API fails, fall back to no-consultants mode
+  end
+
+  qualified = false
+  booking_token = nil
+  if has_consultants && params[:token]
+    if BookingToken.valid?(params[:token], area_slug: slug)
+      qualified = true
+      booking_token = params[:token]
+    else
+      flash[:error] = t('booking.error_expired_token')
+    end
+  end
+
+  @meta_tags.set! title: service_area.name,
+                  description: service_area.seo_description
+
+  erb :'bookings/index', layout: :'layout/layout2022', locals: {
+    service_area: service_area,
+    consultants: consultants,
+    has_consultants: has_consultants,
+    qualified: qualified,
+    booking_token: booking_token,
+    slug: slug
+  }
+end
+
+post '/qualify-booking' do
+  unless verify_recaptcha
+    flash[:error] = t('booking.error_recaptcha')
+    redirect "/#{session[:locale]}/agendar/#{params[:area_slug]}"
+    return
+  end
+
+  area_slug = params[:area_slug]
+  name = params[:name]
+  email = params[:email]
+  company = params[:company]
+  situation = params[:situation] || ''
+  has_consultants = params[:has_consultants] == 'true'
+
+  if has_consultants && situation.length >= 50
+    token = BookingToken.generate(email: email, area_slug: area_slug)
+    redirect "/#{session[:locale]}/agendar/#{area_slug}?token=#{token}"
+  else
+    mail_data = {
+      name: name,
+      email: email,
+      company: company,
+      message: situation,
+      context: "/agendar/#{area_slug}",
+      language: session[:locale],
+      resource_slug: '',
+      initial_slug: '',
+      can_we_contact: true,
+      suscribe: false
+    }
+    send_mail(mail_data)
+    flash[:notice] = t('booking.inquiry_sent')
+    redirect "/#{session[:locale]}/agendar/#{area_slug}"
+  end
+end
+
+get '/consultant-availability/:id' do
+  unless params[:token] && params[:area_slug] && BookingToken.valid?(params[:token], area_slug: params[:area_slug])
+    halt 403, { error: 'forbidden' }.to_json
+  end
+
+  content_type :json
+  begin
+    response = JsonAPI.new(
+      KeventerAPI.consultant_availability_url(
+        params[:id],
+        start: params[:start],
+        end: params[:end],
+        timezone: params[:timezone]
+      )
+    )
+    if response.ok?
+      response.doc.to_json
+    else
+      status 502
+      { error: 'upstream_error' }.to_json
+    end
+  rescue StandardError => e
+    status 502
+    { error: 'upstream_error' }.to_json
+  end
+end
+
+post '/book-meeting' do
+  content_type :json
+
+  unless params[:booking_token] && params[:area_slug] && BookingToken.valid?(params[:booking_token], area_slug: params[:area_slug])
+    halt 403, { error: 'forbidden' }.to_json
+  end
+
+  begin
+    url = KeventerAPI.consultant_booking_url(params[:consultant_id])
+    response = Faraday.post(url) do |req|
+      req.headers['Content-Type'] = 'application/json'
+      req.body = {
+        secret: ENV['CONTACT_US_SECRET'],
+        visitor_name: params[:visitor_name],
+        visitor_email: params[:visitor_email],
+        start_time: params[:start_time],
+        timezone: params[:timezone],
+        service_area_id: params[:service_area_id]
+      }.to_json
+    end
+
+    if response.status == 200 || response.status == 201
+      JSON.parse(response.body).to_json
+    else
+      status response.status
+      { error: 'booking_failed' }.to_json
+    end
+  rescue StandardError => e
+    status 502
+    { error: 'upstream_error' }.to_json
+  end
+end
+
+post '/send-booking-inquiry' do
+  unless params[:booking_token] && params[:area_slug] && BookingToken.valid?(params[:booking_token], area_slug: params[:area_slug])
+    halt 403
+  end
+
+  mail_data = {
+    name: params[:name],
+    email: params[:email],
+    company: params[:company],
+    message: params[:message],
+    context: "/agendar/#{params[:area_slug]}",
+    language: session[:locale],
+    resource_slug: '',
+    initial_slug: '',
+    can_we_contact: true,
+    suscribe: false
+  }
+  send_mail(mail_data)
+  flash[:notice] = t('booking.inquiry_sent')
+  redirect "/#{session[:locale]}/agendar/#{params[:area_slug]}"
+end

--- a/lib/services/booking_token.rb
+++ b/lib/services/booking_token.rb
@@ -1,0 +1,39 @@
+require 'openssl'
+require 'base64'
+require 'json'
+require 'rack/utils'
+
+module BookingToken
+  TTL = 30 * 60 # 30 minutes
+
+  module_function
+
+  def secret
+    ENV.fetch('CONTACT_US_SECRET') { raise 'CONTACT_US_SECRET not set' }
+  end
+
+  def generate(email:, area_slug:)
+    payload = { email: email, area_slug: area_slug, timestamp: Time.now.to_i }.to_json
+    signature = OpenSSL::HMAC.digest('SHA256', secret, payload)
+    Base64.urlsafe_encode64(signature + payload)
+  end
+
+  def valid?(token, area_slug:)
+    return false if token.nil? || token.empty?
+
+    decoded = Base64.urlsafe_decode64(token)
+    signature = decoded[0, 32]
+    payload_json = decoded[32..]
+
+    expected_signature = OpenSSL::HMAC.digest('SHA256', secret, payload_json)
+    return false unless Rack::Utils.secure_compare(signature, expected_signature)
+
+    payload = JSON.parse(payload_json)
+    return false unless payload['area_slug'] == area_slug
+    return false if Time.now.to_i - payload['timestamp'] > TTL
+
+    true
+  rescue ArgumentError, JSON::ParserError
+    false
+  end
+end

--- a/lib/services/keventer_api.rb
+++ b/lib/services/keventer_api.rb
@@ -54,6 +54,7 @@ module KeventerAPI
   {
     service_area: ['service_areas/:slug.json', :slug],
     service_area_preview: ['service_areas/:slug/preview.json', :slug],
+    service_area_consultants: ['service_areas/:slug/consultants', :slug],
     event_type: ['event_types/:id.json', :id],
     article: ['articles/:slug.json', :slug],
     resource: ['resources/:slug.json', :slug],
@@ -62,7 +63,9 @@ module KeventerAPI
     contact_status: ['contacts/:id/status.json', :id],
     contact: ['contacts/:id.json', :id],
     event: ['events/:id.json', :id],
-    participant_register: ['v3/events/:id/participants/register', :id]
+    participant_register: ['v3/events/:id/participants/register', :id],
+    consultant_availability: ['consultants/:id/availability', :id],
+    consultant_booking: ['consultants/:id/bookings', :id]
   }.each do |name, (path, param)|
     define_method("#{name}_url") do |value, params = {}|
       echo(url_for(path.gsub(":#{param}", value.to_s), params))

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1101,6 +1101,27 @@ en:
     error: An error occurred, your message was not sent
     success: Your message has been sent successfully
     quote_message: <b>Thank you for your interest!</b><br>Within the next 48 business hours, we will send you a proposal tailored to your request.
+  booking:
+    tell_us: Tell us about your situation
+    name_label: Name
+    email_label: Email
+    company_label: Company
+    situation_label: Your situation
+    situation_hint: A detailed description (50+ characters) lets you schedule directly with a consultant
+    situation_hint_no_consultants: Your context and challenges will help us prepare for our meeting
+    situation_placeholder: Briefly describe your context, challenges, and what you're looking for...
+    qualify_submit: Submit
+    inquiry_sent: <b>Thank you!</b><br>We received your inquiry and will contact you soon.
+    schedule_option: Schedule a meeting
+    send_option: Just send message
+    char_counter: "%{count} / 50 characters"
+    error_recaptcha: A verification error occurred, please try again
+    error_expired_token: Your session expired, please fill out the form again
+    booking_confirmed: <b>Meeting scheduled!</b><br>You will receive a confirmation email shortly.
+    no_consultants_title: Contact us
+    select_time: Select an available time
+    confirm_booking: Confirm meeting
+    timezone_label: Timezone
   certificates:
     not_found: We couldn't find a certificate with that code
   certificate-form:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -764,6 +764,27 @@ es:
     error: Ha ocurrido un error, su mensaje no fué enviado
     success: Su mensaje ha sido enviado correctamente
     quote_message: <b>¡Gracias por tu interés!</b><br>En las próximas 48hs hábiles te enviaremos una propuesta adaptada a tu pedido.
+  booking:
+    tell_us: Contanos sobre tu situación
+    name_label: Nombre
+    email_label: Email
+    company_label: Empresa
+    situation_label: Tu situación
+    situation_hint: Una descripción detallada (50+ caracteres) te permite agendar directamente con un consultor
+    situation_hint_no_consultants: Tu contexto y desafíos nos ayudarán a prepararnos para nuestra reunión
+    situation_placeholder: Describí brevemente tu contexto, desafíos y qué estás buscando...
+    qualify_submit: Enviar
+    inquiry_sent: <b>¡Gracias!</b><br>Recibimos tu consulta y te contactaremos pronto.
+    schedule_option: Agendar una reunión
+    send_option: Solo enviar mensaje
+    char_counter: "%{count} / 50 caracteres"
+    error_recaptcha: Ha ocurrido un error de verificación, por favor intentá de nuevo
+    error_expired_token: Tu sesión expiró, por favor completá el formulario nuevamente
+    booking_confirmed: <b>¡Reunión agendada!</b><br>Recibirás un email de confirmación en breve.
+    no_consultants_title: Contactanos
+    select_time: Seleccioná un horario disponible
+    confirm_booking: Confirmar reunión
+    timezone_label: Zona horaria
   certificates:
     not_found: No encontramos un certificado con ese código
   certificate-form:

--- a/public/js/booking.js
+++ b/public/js/booking.js
@@ -1,0 +1,182 @@
+document.addEventListener('DOMContentLoaded', function () {
+  // Character counter for situation textarea
+  var textarea = document.getElementById('booking-situation');
+  var counter = document.getElementById('booking-char-counter');
+
+  if (textarea && counter) {
+    var threshold = parseInt(textarea.getAttribute('data-char-threshold') || '50', 10);
+
+    textarea.addEventListener('input', function () {
+      var len = textarea.value.length;
+      counter.textContent = len + ' / ' + threshold;
+      if (len >= threshold) {
+        counter.classList.add('text-success');
+        counter.classList.remove('text-muted');
+      } else {
+        counter.classList.remove('text-success');
+        counter.classList.add('text-muted');
+      }
+    });
+  }
+
+  // Bootstrap form validation
+  var form = document.getElementById('booking-qualify-form');
+  if (form) {
+    form.addEventListener('submit', function (event) {
+      if (!form.checkValidity()) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+      form.classList.add('was-validated');
+    });
+  }
+
+  // Schedule button toggle
+  var btnSchedule = document.getElementById('btn-schedule');
+  var consultantPanel = document.getElementById('consultant-panel');
+
+  if (btnSchedule && consultantPanel) {
+    btnSchedule.addEventListener('click', function () {
+      consultantPanel.style.display = 'block';
+      btnSchedule.disabled = true;
+      loadAllAvailability();
+    });
+  }
+
+  // Timezone change reloads availability
+  var timezoneSelect = document.getElementById('booking-timezone');
+  if (timezoneSelect) {
+    timezoneSelect.addEventListener('change', function () {
+      loadAllAvailability();
+    });
+  }
+});
+
+function loadAllAvailability() {
+  if (typeof BOOKING_CONFIG === 'undefined') return;
+
+  var timezone = document.getElementById('booking-timezone').value;
+  var start = new Date().toISOString().split('T')[0];
+  var endDate = new Date();
+  endDate.setDate(endDate.getDate() + 14);
+  var end = endDate.toISOString().split('T')[0];
+
+  BOOKING_CONFIG.consultantIds.forEach(function (id) {
+    loadConsultantAvailability(id, start, end, timezone);
+  });
+}
+
+function loadConsultantAvailability(consultantId, start, end, timezone) {
+  var card = document.querySelector('[data-consultant-id="' + consultantId + '"]');
+  if (!card) return;
+
+  var slotsContainer = card.querySelector('.availability-slots');
+  slotsContainer.innerHTML = '<div class="text-center py-3"><div class="spinner-border spinner-border-sm" role="status"><span class="visually-hidden">Loading...</span></div></div>';
+
+  var url = '/' + BOOKING_CONFIG.locale + '/consultant-availability/' + consultantId +
+    '?token=' + encodeURIComponent(BOOKING_CONFIG.token) +
+    '&area_slug=' + encodeURIComponent(BOOKING_CONFIG.areaSlug) +
+    '&start=' + encodeURIComponent(start) +
+    '&end=' + encodeURIComponent(end) +
+    '&timezone=' + encodeURIComponent(timezone);
+
+  fetch(url)
+    .then(function (response) {
+      if (!response.ok) throw new Error('Failed to load availability');
+      return response.json();
+    })
+    .then(function (slots) {
+      renderSlots(slotsContainer, slots, consultantId);
+    })
+    .catch(function () {
+      slotsContainer.innerHTML = '<p class="text-muted small">Could not load availability.</p>';
+    });
+}
+
+function renderSlots(container, slots, consultantId) {
+  if (!slots || slots.length === 0) {
+    container.innerHTML = '<p class="text-muted small">No available slots in the next 2 weeks.</p>';
+    return;
+  }
+
+  var html = '<div class="d-flex flex-wrap gap-2">';
+  slots.forEach(function (slot) {
+    var date = new Date(slot.start_time);
+    var label = date.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' }) +
+      ' ' + date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+
+    html += '<button type="button" class="btn btn-outline-primary btn-sm slot-btn" ' +
+      'data-consultant-id="' + consultantId + '" ' +
+      'data-start-time="' + slot.start_time + '" ' +
+      'onclick="selectSlot(this)">' +
+      label + '</button>';
+  });
+  html += '</div>';
+
+  container.innerHTML = html;
+}
+
+function selectSlot(btn) {
+  // Deselect all
+  document.querySelectorAll('.slot-btn.active').forEach(function (el) {
+    el.classList.remove('active');
+  });
+
+  // Select this one
+  btn.classList.add('active');
+
+  // Show confirm button if not present
+  var panel = document.getElementById('consultant-panel');
+  var existing = document.getElementById('confirm-booking-btn');
+  if (!existing) {
+    var confirmBtn = document.createElement('button');
+    confirmBtn.id = 'confirm-booking-btn';
+    confirmBtn.className = 'btn btn-success mt-3';
+    confirmBtn.textContent = BOOKING_CONFIG.confirmText;
+    confirmBtn.onclick = function () { confirmBooking(btn); };
+    panel.appendChild(confirmBtn);
+  } else {
+    existing.onclick = function () { confirmBooking(btn); };
+  }
+}
+
+function confirmBooking(slotBtn) {
+  var confirmBtn = document.getElementById('confirm-booking-btn');
+  confirmBtn.disabled = true;
+  confirmBtn.textContent = '...';
+
+  var timezone = document.getElementById('booking-timezone').value;
+
+  var formData = new FormData();
+  formData.append('booking_token', BOOKING_CONFIG.token);
+  formData.append('area_slug', BOOKING_CONFIG.areaSlug);
+  formData.append('consultant_id', slotBtn.getAttribute('data-consultant-id'));
+  formData.append('start_time', slotBtn.getAttribute('data-start-time'));
+  formData.append('timezone', timezone);
+  formData.append('service_area_id', BOOKING_CONFIG.serviceAreaId);
+  formData.append('visitor_name', '');
+  formData.append('visitor_email', '');
+
+  fetch('/' + BOOKING_CONFIG.locale + '/book-meeting', {
+    method: 'POST',
+    body: formData
+  })
+    .then(function (response) {
+      if (!response.ok) throw new Error('Booking failed');
+      return response.json();
+    })
+    .then(function () {
+      confirmBtn.textContent = BOOKING_CONFIG.confirmedText;
+      confirmBtn.classList.remove('btn-success');
+      confirmBtn.classList.add('btn-outline-success');
+      // Disable all slot buttons
+      document.querySelectorAll('.slot-btn').forEach(function (el) {
+        el.disabled = true;
+      });
+    })
+    .catch(function () {
+      confirmBtn.disabled = false;
+      confirmBtn.textContent = BOOKING_CONFIG.confirmText;
+      confirmBtn.classList.add('btn-danger');
+    });
+}

--- a/spec/lib/services/booking_token_spec.rb
+++ b/spec/lib/services/booking_token_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+require './lib/services/booking_token'
+
+describe BookingToken do
+  before do
+    allow(ENV).to receive(:fetch).with('CONTACT_US_SECRET').and_return('test-secret-key-123')
+  end
+
+  describe '.generate' do
+    it 'returns a Base64-encoded string' do
+      token = BookingToken.generate(email: 'user@example.com', area_slug: 'agile-coaching')
+      expect(token).to be_a(String)
+      expect { Base64.urlsafe_decode64(token) }.not_to raise_error
+    end
+  end
+
+  describe '.valid?' do
+    it 'accepts a freshly generated token with matching area_slug' do
+      token = BookingToken.generate(email: 'user@example.com', area_slug: 'agile-coaching')
+      expect(BookingToken.valid?(token, area_slug: 'agile-coaching')).to be true
+    end
+
+    it 'rejects a token with a different area_slug' do
+      token = BookingToken.generate(email: 'user@example.com', area_slug: 'agile-coaching')
+      expect(BookingToken.valid?(token, area_slug: 'other-area')).to be false
+    end
+
+    it 'rejects an expired token (>30 min)' do
+      token = BookingToken.generate(email: 'user@example.com', area_slug: 'agile-coaching')
+      allow(Time).to receive(:now).and_return(Time.now + 31 * 60)
+      expect(BookingToken.valid?(token, area_slug: 'agile-coaching')).to be false
+    end
+
+    it 'rejects a tampered token' do
+      token = BookingToken.generate(email: 'user@example.com', area_slug: 'agile-coaching')
+      tampered = token[0..-2] + (token[-1] == 'A' ? 'B' : 'A')
+      expect(BookingToken.valid?(tampered, area_slug: 'agile-coaching')).to be false
+    end
+
+    it 'rejects nil token' do
+      expect(BookingToken.valid?(nil, area_slug: 'agile-coaching')).to be false
+    end
+
+    it 'rejects empty token' do
+      expect(BookingToken.valid?('', area_slug: 'agile-coaching')).to be false
+    end
+
+    it 'rejects garbage input' do
+      expect(BookingToken.valid?('not-a-valid-token!!!', area_slug: 'agile-coaching')).to be false
+    end
+  end
+
+  describe '.secret' do
+    it 'raises when CONTACT_US_SECRET is not set' do
+      allow(ENV).to receive(:fetch).with('CONTACT_US_SECRET').and_call_original
+      # Temporarily remove the env var
+      allow(ENV).to receive(:fetch).with('CONTACT_US_SECRET').and_raise(KeyError.new('key not found: "CONTACT_US_SECRET"'))
+      expect { BookingToken.secret }.to raise_error(KeyError)
+    end
+  end
+end

--- a/spec/requests/bookings_spec.rb
+++ b/spec/requests/bookings_spec.rb
@@ -1,0 +1,292 @@
+require 'spec_helper'
+require 'sinatra/flash'
+require './app'
+require './lib/services/booking_token'
+require './lib/services/mailer'
+
+describe 'Bookings' do
+  def app
+    Sinatra::Application.new
+  end
+
+  let(:service_area_data) do
+    {
+      'id' => 42,
+      'slug' => 'agile-coaching',
+      'name' => 'Agile Coaching',
+      'lang' => 'es',
+      'primary_color' => '#FF5733',
+      'primary_font_color' => '#FFFFFF',
+      'secondary_color' => '#33FF57',
+      'secondary_font_color' => '#000000',
+      'seo_title' => 'Agile Coaching',
+      'seo_description' => 'Coaching services',
+      'is_training_program' => false,
+      'services' => []
+    }
+  end
+
+  let(:consultants_data) do
+    [
+      { 'id' => 1, 'name' => 'Jane Doe', 'gravatar_email' => 'jane@example.com', 'bio' => 'Coach' },
+      { 'id' => 2, 'name' => 'John Smith', 'gravatar_email' => 'john@example.com', 'bio' => 'Trainer' }
+    ]
+  end
+
+  let(:null_service_area_api) { NullJsonAPI.new(nil, service_area_data.to_json) }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('CONTACT_US_SECRET').and_return('test-secret')
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('RECAPTCHA_SITE_KEY').and_return('test-site-key')
+    env 'rack.session', { locale: 'es' }
+  end
+
+  after do
+    ServiceAreaV3.class_variable_set(:@@json_api, nil) if ServiceAreaV3.class_variable_defined?(:@@json_api)
+  end
+
+  describe 'GET /agendar/:slug' do
+    context 'with consultants available' do
+      before do
+        ServiceAreaV3.null_json_api(nil, null_service_area_api)
+        allow(JsonAPI).to receive(:new).and_call_original
+        consultants_response = NullJsonAPI.new(nil, consultants_data.to_json)
+        allow(JsonAPI).to receive(:new)
+          .with(KeventerAPI.service_area_consultants_url('agile-coaching'))
+          .and_return(consultants_response)
+      end
+
+      it 'renders the qualification form without a token' do
+        get '/es/agendar/agile-coaching'
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include('booking-qualify-form')
+        expect(last_response.body).to include('data-char-threshold="50"')
+      end
+
+      it 'renders qualified options with a valid token' do
+        token = BookingToken.generate(email: 'user@test.com', area_slug: 'agile-coaching')
+        get "/es/agendar/agile-coaching?token=#{token}"
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include('btn-schedule')
+        expect(last_response.body).to include('Jane Doe')
+      end
+
+      it 'renders the qualification form with an expired token' do
+        token = BookingToken.generate(email: 'user@test.com', area_slug: 'agile-coaching')
+        allow(Time).to receive(:now).and_return(Time.now + 31 * 60)
+
+        get "/es/agendar/agile-coaching?token=#{token}"
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include('booking-qualify-form')
+      end
+    end
+
+    context 'with no consultants available' do
+      before do
+        ServiceAreaV3.null_json_api(nil, null_service_area_api)
+        empty_response = NullJsonAPI.new(nil, [].to_json)
+        allow(JsonAPI).to receive(:new).and_call_original
+        allow(JsonAPI).to receive(:new)
+          .with(KeventerAPI.service_area_consultants_url('agile-coaching'))
+          .and_return(empty_response)
+      end
+
+      it 'renders the contact-only form with generic hint' do
+        get '/es/agendar/agile-coaching'
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include('booking-qualify-form')
+        expect(last_response.body).not_to include('data-char-threshold')
+      end
+    end
+
+    context 'with nonexistent service area' do
+      before do
+        null_api = NullJsonAPI.new(nil, nil)
+        ServiceAreaV3.null_json_api(nil, null_api)
+      end
+
+      it 'returns 404' do
+        get '/es/agendar/nonexistent-slug'
+
+        expect(last_response.status).to eq(404)
+      end
+    end
+  end
+
+  describe 'POST /qualify-booking' do
+    let(:mailer_instance) { instance_double(Mailer) }
+
+    before do
+      allow_any_instance_of(Sinatra::Application).to receive(:verify_recaptcha).and_return(true)
+      allow(Mailer).to receive(:new).and_return(mailer_instance)
+      env 'rack.session', { locale: 'es', flash: {} }
+    end
+
+    context 'with consultants and description >= 50 chars' do
+      it 'redirects with a token' do
+        post '/es/qualify-booking', {
+          'name' => 'Test User',
+          'email' => 'test@example.com',
+          'company' => 'TestCo',
+          'situation' => 'A' * 50,
+          'area_slug' => 'agile-coaching',
+          'has_consultants' => 'true'
+        }
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.location).to include('/es/agendar/agile-coaching?token=')
+      end
+    end
+
+    context 'with consultants and description < 50 chars' do
+      it 'sends mail and redirects without token' do
+        expect(Mailer).to receive(:new).with(
+          KeventerAPI.mailer_url,
+          hash_including(name: 'Test User', email: 'test@example.com')
+        )
+
+        post '/es/qualify-booking', {
+          'name' => 'Test User',
+          'email' => 'test@example.com',
+          'company' => 'TestCo',
+          'situation' => 'Short description',
+          'area_slug' => 'agile-coaching',
+          'has_consultants' => 'true'
+        }
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.location).to include('/es/agendar/agile-coaching')
+        expect(last_response.location).not_to include('token=')
+      end
+    end
+
+    context 'without consultants' do
+      it 'always sends mail regardless of description length' do
+        expect(Mailer).to receive(:new).with(
+          KeventerAPI.mailer_url,
+          hash_including(name: 'Test User')
+        )
+
+        post '/es/qualify-booking', {
+          'name' => 'Test User',
+          'email' => 'test@example.com',
+          'company' => 'TestCo',
+          'situation' => 'A' * 100,
+          'area_slug' => 'agile-coaching',
+          'has_consultants' => 'false'
+        }
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.location).to include('/es/agendar/agile-coaching')
+        expect(last_response.location).not_to include('token=')
+      end
+    end
+
+    context 'with invalid recaptcha' do
+      before do
+        allow_any_instance_of(Sinatra::Application).to receive(:verify_recaptcha).and_return(false)
+      end
+
+      it 'redirects with error' do
+        post '/es/qualify-booking', {
+          'name' => 'Test User',
+          'email' => 'test@example.com',
+          'situation' => 'Some text',
+          'area_slug' => 'agile-coaching',
+          'has_consultants' => 'true'
+        }
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.location).to include('/es/agendar/agile-coaching')
+      end
+    end
+  end
+
+  describe 'GET /consultant-availability/:id' do
+    it 'returns 403 without a valid token' do
+      get '/es/consultant-availability/1'
+
+      expect(last_response.status).to eq(403)
+    end
+
+    it 'returns 403 with an invalid token' do
+      get '/es/consultant-availability/1?token=invalid&area_slug=agile-coaching'
+
+      expect(last_response.status).to eq(403)
+    end
+
+    it 'proxies the API response with a valid token' do
+      token = BookingToken.generate(email: 'user@test.com', area_slug: 'agile-coaching')
+      availability_data = [{ 'start_time' => '2026-04-20T10:00:00Z' }]
+      availability_response = NullJsonAPI.new(nil, availability_data.to_json)
+
+      allow(JsonAPI).to receive(:new).and_return(availability_response)
+
+      get "/es/consultant-availability/1?token=#{token}&area_slug=agile-coaching&start=2026-04-16&end=2026-04-30&timezone=America/Buenos_Aires"
+
+      expect(last_response.status).to eq(200)
+      parsed = JSON.parse(last_response.body)
+      expect(parsed).to be_an(Array)
+      expect(parsed.first['start_time']).to eq('2026-04-20T10:00:00Z')
+    end
+  end
+
+  describe 'POST /book-meeting' do
+    it 'returns 403 without a valid token' do
+      post '/es/book-meeting', { 'consultant_id' => '1' }
+
+      expect(last_response.status).to eq(403)
+    end
+
+    it 'returns 403 with an invalid token' do
+      post '/es/book-meeting', {
+        'booking_token' => 'invalid',
+        'area_slug' => 'agile-coaching',
+        'consultant_id' => '1'
+      }
+
+      expect(last_response.status).to eq(403)
+    end
+  end
+
+  describe 'POST /send-booking-inquiry' do
+    let(:mailer_instance) { instance_double(Mailer) }
+
+    before do
+      allow(Mailer).to receive(:new).and_return(mailer_instance)
+      env 'rack.session', { locale: 'es', flash: {} }
+    end
+
+    it 'returns 403 without a valid token' do
+      post '/es/send-booking-inquiry', { 'area_slug' => 'agile-coaching' }
+
+      expect(last_response.status).to eq(403)
+    end
+
+    it 'sends mail and redirects with a valid token' do
+      token = BookingToken.generate(email: 'user@test.com', area_slug: 'agile-coaching')
+
+      expect(Mailer).to receive(:new).with(
+        KeventerAPI.mailer_url,
+        hash_including(context: '/agendar/agile-coaching')
+      )
+
+      post '/es/send-booking-inquiry', {
+        'booking_token' => token,
+        'area_slug' => 'agile-coaching',
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'message' => 'Please help us'
+      }
+
+      expect(last_response.status).to eq(302)
+      expect(last_response.location).to include('/es/agendar/agile-coaching')
+    end
+  end
+end

--- a/views/bookings/_qualification_form.erb
+++ b/views/bookings/_qualification_form.erb
@@ -1,0 +1,94 @@
+<h2 class="mb-3">
+  <% if has_consultants %>
+    <%= t('booking.tell_us') %>
+  <% else %>
+    <%= t('booking.no_consultants_title') %>
+  <% end %>
+</h2>
+
+<form id="booking-qualify-form" action="/<%= session[:locale] || 'es' %>/qualify-booking" method="post" class="needs-validation" novalidate>
+  <div class="row">
+    <div class="mb-3 col-12">
+      <label class="form-label" for="booking-name"><%= t('booking.name_label') %></label>
+      <input type="text" class="form-control" name="name" id="booking-name" required>
+      <div class="invalid-feedback"><%= t('booking.name_label') %></div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="mb-3 col-12 col-md-6">
+      <label class="form-label" for="booking-email"><%= t('booking.email_label') %></label>
+      <input type="email" class="form-control" name="email" id="booking-email" required>
+      <div class="invalid-feedback"><%= t('booking.email_label') %></div>
+    </div>
+    <div class="mb-3 col-12 col-md-6">
+      <label class="form-label" for="booking-company"><%= t('booking.company_label') %></label>
+      <input type="text" class="form-control" name="company" id="booking-company">
+    </div>
+  </div>
+  <div class="mb-3">
+    <label class="form-label" for="booking-situation"><%= t('booking.situation_label') %></label>
+    <div class="form-text">
+      <% if has_consultants %>
+        <%= t('booking.situation_hint') %>
+      <% else %>
+        <%= t('booking.situation_hint_no_consultants') %>
+      <% end %>
+    </div>
+    <textarea class="form-control" name="situation" id="booking-situation" rows="4"
+              placeholder="<%= t('booking.situation_placeholder') %>" required
+              <% if has_consultants %>data-char-threshold="50"<% end %>
+    ></textarea>
+    <% if has_consultants %>
+      <div class="form-text" id="booking-char-counter">0 / 50</div>
+    <% end %>
+    <div class="invalid-feedback"><%= t('booking.situation_label') %></div>
+  </div>
+
+  <div id="recaptcha-placeholder" class="mb-3"></div>
+
+  <input type="hidden" name="area_slug" value="<%= slug %>">
+  <input type="hidden" name="has_consultants" value="<%= has_consultants %>">
+
+  <div class="d-grid">
+    <button type="submit" id="booking-submit" class="btn btn-primary" disabled>
+      <%= t('booking.qualify_submit') %>
+    </button>
+  </div>
+</form>
+
+<script>
+  var RECAPTCHA_SITE_KEY = '<%= ENV["RECAPTCHA_SITE_KEY"] %>';
+
+  document.addEventListener('DOMContentLoaded', function() {
+    loadBookingRecaptcha();
+  });
+
+  function loadBookingRecaptcha() {
+    if (typeof grecaptcha !== 'undefined' && grecaptcha.render) {
+      initBookingRecaptcha();
+      return;
+    }
+    if (!document.querySelector('script[src*="recaptcha/api.js"]')) {
+      var script = document.createElement('script');
+      script.src = 'https://www.recaptcha.net/recaptcha/api.js?render=explicit';
+      script.async = true;
+      script.defer = true;
+      script.onload = function() { initBookingRecaptcha(); };
+      document.body.appendChild(script);
+    }
+  }
+
+  function initBookingRecaptcha() {
+    var placeholder = document.querySelector('#booking-qualify-form #recaptcha-placeholder');
+    if (!placeholder) return;
+    placeholder.innerHTML = '<div id="booking-recaptcha-widget"></div>';
+    grecaptcha.ready(function() {
+      grecaptcha.render('booking-recaptcha-widget', {
+        'sitekey': RECAPTCHA_SITE_KEY,
+        'callback': function() {
+          document.getElementById('booking-submit').disabled = false;
+        }
+      });
+    });
+  }
+</script>

--- a/views/bookings/_qualified_options.erb
+++ b/views/bookings/_qualified_options.erb
@@ -1,0 +1,70 @@
+<div class="mb-4">
+  <div class="d-flex gap-3 mb-4">
+    <button type="button" class="btn btn-primary" id="btn-schedule">
+      <%= t('booking.schedule_option') %>
+    </button>
+    <form action="/<%= session[:locale] || 'es' %>/send-booking-inquiry" method="post" class="d-inline">
+      <input type="hidden" name="booking_token" value="<%= booking_token %>">
+      <input type="hidden" name="area_slug" value="<%= slug %>">
+      <button type="submit" class="btn btn-outline-secondary">
+        <%= t('booking.send_option') %>
+      </button>
+    </form>
+  </div>
+</div>
+
+<div id="consultant-panel" style="display: none;">
+  <h3 class="mb-3"><%= t('booking.select_time') %></h3>
+
+  <div class="mb-3">
+    <label class="form-label" for="booking-timezone"><%= t('booking.timezone_label') %></label>
+    <select class="form-select" id="booking-timezone">
+      <option value="America/Argentina/Buenos_Aires">Buenos Aires (GMT-3)</option>
+      <option value="America/Santiago">Santiago (GMT-4)</option>
+      <option value="America/Bogota">Bogotá (GMT-5)</option>
+      <option value="America/Mexico_City">Ciudad de México (GMT-6)</option>
+      <option value="America/New_York">New York (GMT-5)</option>
+      <option value="Europe/Madrid">Madrid (GMT+1)</option>
+    </select>
+  </div>
+
+  <div id="consultants-list" class="row g-3">
+    <% consultants.each do |consultant| %>
+      <div class="col-md-6">
+        <div class="card consultant-card" data-consultant-id="<%= consultant['id'] %>">
+          <div class="card-body">
+            <div class="d-flex align-items-center mb-3">
+              <img src="https://www.gravatar.com/avatar/<%= Digest::MD5.hexdigest(consultant['gravatar_email'].to_s.downcase.strip) %>?s=48&d=mp"
+                   class="rounded-circle me-3" width="48" height="48" alt="<%= consultant['name'] %>">
+              <div>
+                <h5 class="card-title mb-0"><%= consultant['name'] %></h5>
+                <% if consultant['bio'] %>
+                  <small class="text-muted"><%= consultant['bio'] %></small>
+                <% end %>
+              </div>
+            </div>
+            <div class="availability-slots">
+              <div class="text-center py-3">
+                <div class="spinner-border spinner-border-sm" role="status">
+                  <span class="visually-hidden">Loading...</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<script>
+  var BOOKING_CONFIG = {
+    token: '<%= booking_token %>',
+    areaSlug: '<%= slug %>',
+    serviceAreaId: '<%= service_area.id %>',
+    locale: '<%= session[:locale] || "es" %>',
+    consultantIds: <%= consultants.map { |c| c['id'] }.to_json %>,
+    confirmText: '<%= t("booking.confirm_booking") %>',
+    confirmedText: '<%= t("booking.booking_confirmed") %>'
+  };
+</script>

--- a/views/bookings/index.erb
+++ b/views/bookings/index.erb
@@ -1,0 +1,30 @@
+<div class="container py-5">
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      <h1 class="mb-4"><%= service_area.name %></h1>
+
+      <% if flash[:notice] %>
+        <div class="alert alert-success" role="alert"><%= flash[:notice] %></div>
+      <% end %>
+      <% if flash[:error] %>
+        <div class="alert alert-warning" role="alert"><%= flash[:error] %></div>
+      <% end %>
+
+      <% if qualified %>
+        <%= erb :'bookings/_qualified_options', locals: {
+          service_area: service_area,
+          consultants: consultants,
+          booking_token: booking_token,
+          slug: slug
+        } %>
+      <% else %>
+        <%= erb :'bookings/_qualification_form', locals: {
+          service_area: service_area,
+          has_consultants: has_consultants,
+          slug: slug
+        } %>
+      <% end %>
+    </div>
+  </div>
+</div>
+<script src="/js/booking.js" defer></script>


### PR DESCRIPTION
## Summary
This PR introduces a complete booking system that allows users to schedule meetings with consultants. The system includes a two-stage qualification flow: users first provide their details and situation description, and if they meet criteria (50+ character description with available consultants), they receive a token to directly schedule with a consultant. Otherwise, their inquiry is sent via email.

## Key Changes

- **Booking Controller** (`controllers/bookings_controller.rb`): New controller with 5 endpoints:
  - `GET /agendar/:slug` - Displays booking page with qualification form or consultant selection
  - `POST /qualify-booking` - Processes qualification form, generates token if eligible, or sends email inquiry
  - `GET /consultant-availability/:id` - Proxies consultant availability data (token-protected)
  - `POST /book-meeting` - Creates booking with selected consultant (token-protected)
  - `POST /send-booking-inquiry` - Sends inquiry email from qualified users

- **Booking Token Service** (`lib/services/booking_token.rb`): HMAC-SHA256 based token generation and validation
  - Tokens include email, area_slug, and timestamp
  - 30-minute TTL with secure comparison to prevent timing attacks
  - Validates area_slug matches to prevent token reuse across service areas

- **Frontend Views**:
  - `views/bookings/index.erb` - Main booking page layout
  - `views/bookings/_qualification_form.erb` - Initial form with reCAPTCHA integration and character counter
  - `views/bookings/_qualified_options.erb` - Consultant selection interface with timezone support

- **Client-side JavaScript** (`public/js/booking.js`): 
  - Character counter for situation textarea with visual feedback
  - Dynamic availability loading for selected consultants
  - Slot selection and booking confirmation with loading states
  - Timezone-aware scheduling

- **API Integration** (`lib/services/keventer_api.rb`): Added `service_area_consultants` endpoint

- **Localization**: Added booking-related strings in English and Spanish locales

## Notable Implementation Details

- Token validation uses `Rack::Utils.secure_compare` to prevent timing attacks
- Qualification logic: users with 50+ character descriptions and available consultants get direct scheduling; others receive email handling
- Consultant availability is loaded dynamically via AJAX with timezone support
- reCAPTCHA is integrated into the qualification form to prevent spam
- All token-protected endpoints return 403 Forbidden for invalid/missing tokens
- Graceful fallback when consultant API is unavailable (treated as no-consultants mode)

https://claude.ai/code/session_01AQy1Ht4o47dJ1KRmvA2Suv